### PR TITLE
Update web background colour

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,5 +10,6 @@ body {
   padding: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #FCFCFC;
 }
 


### PR DESCRIPTION
Fix the white gap between About us and Get Involved. The reason for it is when we calls mt-60 on line 87 in src/pages/HomePage.jsx which move the About Us section below expose the website default background color which is white. Changing the background color should fix the issue.