### PR TITLE
Homepage overlap

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -89,7 +89,7 @@ const HomePage = () => {
       )}
       <div> 
         <img
-          className={`${isSmallScreen ? ' mt-80 block' : ''} min-w-[600px] absolute w-[600px]  z-[-1] right-0`}
+          className={`${isSmallScreen ? ' mt-96 block min-w-[400px] w-[400px]' : 'min-w-[600px] w-[600px]'} absolute  z-[-1] right-0`}
           src={HomeBGFull}
           alt="about us header"
           fetchPriority="high"
@@ -106,7 +106,7 @@ const HomePage = () => {
         fetchPriority="high"
       />
       <div className="mb-[100px] mx-12 px-3 md:px-[15%] overflow-x-none">
-        <Landing className={`${isSmallScreen ? 'mt-52' : 'mt-32'} !font-semibold md:w-[600px]`}>
+        <Landing className={`${isSmallScreen ? 'mt-56' : 'mt-32'} !font-semibold md:w-[600px]`}>
           {t("home.header.title")}
         </Landing>
         <ParagraphText className="md:w-[400px] mb-3 md:mb-6">
@@ -116,7 +116,7 @@ const HomePage = () => {
           {t("home.header.button")}
         </OutlineButton>
       </div>
-      <div style={{ paddingTop: isSmallScreen ? '750px' : '0' }} className={`${isSmallScreen ? 'mt-36' : 'mt-64'} px-3 md:px-[15%] mt-40`}>
+      <div style={{ paddingTop: isSmallScreen ? '500px' : '0' }} className={`${isSmallScreen ? 'mt-36' : 'mt-64'} px-3 md:px-[15%] mt-40`}>
 
         <SectionHeader>{t("home.aboutUs.title")}</SectionHeader>
         <ParagraphText className="md:w-[500px] mb-3 md:mb-6">


### PR DESCRIPTION
Tried to fix the overlap with text and some of the graphics on the homepage.

I noticed that on computer view using the screen resizer it doesn't always show the correct display, sometimes need to refresh. I checked on most mobile devices and it seems to not overlap now.

It is not exactly like the figma design because I was running into issues with the scrollbar so I went this direction instead.

It might also be good to add a medium screen size state too.